### PR TITLE
Removing logging of secrets in `publish`

### DIFF
--- a/.circleci/publish-extension.sh
+++ b/.circleci/publish-extension.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 ACCESS_TOKEN=$(curl "https://www.googleapis.com/oauth2/v4/token" -d "client_id=${CLIENT_ID}&client_secret=${CLIENT_SECRET}&refresh_token=${REFRESH_TOKEN}&grant_type=refresh_token" | jq -r .access_token)
-curl -H "Authorization: Bearer ${ACCESS_TOKEN}" -H "x-goog-api-version: 2" -X PUT -T $1 -v "https://www.googleapis.com/upload/chromewebstore/v1.1/items/${APP_ID}"
-curl -H "Authorization: Bearer ${ACCESS_TOKEN}" -H "x-goog-api-version: 2" -H "Content-Length: 0" -X POST -v "https://www.googleapis.com/chromewebstore/v1.1/items/${APP_ID}/publish"
+curl -H "Authorization: Bearer ${ACCESS_TOKEN}" -H "x-goog-api-version: 2" -X PUT -T $1 "https://www.googleapis.com/upload/chromewebstore/v1.1/items/${APP_ID}"
+curl -H "Authorization: Bearer ${ACCESS_TOKEN}" -H "x-goog-api-version: 2" -H "Content-Length: 0" -X POST "https://www.googleapis.com/chromewebstore/v1.1/items/${APP_ID}/publish"


### PR DESCRIPTION
- CircleCI `publish` step currently logs the Authorization header
- Run curl in non-verbose mode to prevent it from logging the Auth token