### PR TITLE
allow fixed offers to be loaded in tools/dataProcessor.js

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -7,6 +7,7 @@ This folder contains raw and processed data about **Discover Deals** and **Disco
 ```
 .
 ├── cashback
+│   ├── fixedInputData.json     # Predefined data that need to be included in addition to parsed data
 │   ├── data.json               # Processed cashback data
 │   ├── raw                     # Raw cashback data directory (see section below)
 │   │   ├── 1.html
@@ -96,6 +97,8 @@ So for numbers `1` to `6`, repeat the following steps:
 Congrats! You have now retrieved the latest raw data. This is the hardest part of the process.
 
 Just to double check, you might want to visit `page 7` for the URL above and ensure there are no cashback offers on that page. The html should be fairly short if there are no offers.
+
+In addition to the above, there is also a user-defined file, `/data/cashback/fixedInputData.json` where you can modify offers that cannot be parsed normally. As an example, Discover allows $1 cashback to be redeemed for $1 to spend on Amazon.
 
 ### Process the data
 

--- a/data/cashback/data.json
+++ b/data/cashback/data.json
@@ -1,5 +1,14 @@
 [
   {
+    "site_url": "www.amazon.com",
+    "offers": [
+      "$1 cashback bonus gets you $1 to spend"
+    ],
+    "site_name": "Amazon",
+    "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/offer?page=amazonredeem",
+    "img_src_url": "https://card.discover.com/rewards/images/redeem/logo-amazon.jpg"
+  },
+  {
     "site_url": "www.1800flowers.com",
     "offers": [
       "$20 gets you $30",
@@ -95,7 +104,7 @@
     "site_name": "Bahama Breeze"
   },
   {
-    "site_url": "www.bananarepublic.com",
+    "site_url": "bananarepublic.gap.com",
     "offers": [
       "$20 gets you $25",
       "$40 gets you $50",
@@ -220,7 +229,7 @@
     "site_name": "Buffalo Wild Wings"
   },
   {
-    "site_url": "www.burlingtoncoatfactory.com",
+    "site_url": "www.burlington.com",
     "offers": [
       "$20 gets you $25"
     ],
@@ -631,7 +640,7 @@
     "site_name": "Nordstrom"
   },
   {
-    "site_url": "oldnavy.gap.com",
+    "site_url": "www.oldnavy.com",
     "offers": [
       "$20 gets you $25",
       "$40 gets you $50",
@@ -808,7 +817,7 @@
     "site_name": "Ruth's Chris Steakhouse"
   },
   {
-    "site_url": "www.yellowpages.com",
+    "site_url": "www.saltgrass.com",
     "offers": [
       "$45 gets you $50"
     ],
@@ -922,7 +931,7 @@
     "site_name": "Texas Roadhouse"
   },
   {
-    "site_url": "www.tgifridays.com",
+    "site_url": "locations.tgifridays.com",
     "offers": [
       "$45 gets you $50"
     ],

--- a/data/cashback/fixedInputData.json
+++ b/data/cashback/fixedInputData.json
@@ -1,0 +1,11 @@
+[
+  {
+    "site_url": "www.amazon.com",
+    "offers": [
+      "$1 cashback bonus gets you $1 to spend"
+    ],
+    "site_name": "Amazon",
+    "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/offer?page=amazonredeem",
+    "img_src_url": "https://card.discover.com/rewards/images/redeem/logo-amazon.jpg"
+  }
+]

--- a/docs/cashbacks.json
+++ b/docs/cashbacks.json
@@ -1,5 +1,14 @@
 [
   {
+    "site_url": "www.amazon.com",
+    "offers": [
+      "$1 cashback bonus gets you $1 to spend"
+    ],
+    "site_name": "Amazon",
+    "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/offer?page=amazonredeem",
+    "img_src_url": "https://card.discover.com/rewards/images/redeem/logo-amazon.jpg"
+  },
+  {
     "site_url": "www.1800flowers.com",
     "offers": [
       "$20 gets you $30",
@@ -95,7 +104,7 @@
     "site_name": "Bahama Breeze"
   },
   {
-    "site_url": "www.bananarepublic.com",
+    "site_url": "bananarepublic.gap.com",
     "offers": [
       "$20 gets you $25",
       "$40 gets you $50",
@@ -220,7 +229,7 @@
     "site_name": "Buffalo Wild Wings"
   },
   {
-    "site_url": "www.burlingtoncoatfactory.com",
+    "site_url": "www.burlington.com",
     "offers": [
       "$20 gets you $25"
     ],
@@ -631,7 +640,7 @@
     "site_name": "Nordstrom"
   },
   {
-    "site_url": "oldnavy.gap.com",
+    "site_url": "www.oldnavy.com",
     "offers": [
       "$20 gets you $25",
       "$40 gets you $50",
@@ -808,7 +817,7 @@
     "site_name": "Ruth's Chris Steakhouse"
   },
   {
-    "site_url": "www.yellowpages.com",
+    "site_url": "www.saltgrass.com",
     "offers": [
       "$45 gets you $50"
     ],
@@ -922,7 +931,7 @@
     "site_name": "Texas Roadhouse"
   },
   {
-    "site_url": "www.tgifridays.com",
+    "site_url": "locations.tgifridays.com",
     "offers": [
       "$45 gets you $50"
     ],

--- a/tools/dataProcessor.js
+++ b/tools/dataProcessor.js
@@ -24,6 +24,7 @@ const DEAL_INPUT_FILE = 'data/deal/raw.html';
 const DEAL_OUTPUT_FILE = 'data/deal/data.json';     // For developer use
 const DEAL_OUTPUT_FILE_PROD = 'docs/deals.json';    // Served via the product website for end-users
 const CASHBACK_INPUT_FOLDER = 'data/cashback/raw/';
+const CASHBACK_INPUT_FILE = 'data/cashback/fixedInputData.json'; // Contains fixed cashback offers (e.g. Amazon offer)
 const CASHBACK_OUTPUT_FILE = 'data/cashback/data.json';     // For developer use
 const CASHBACK_OUTPUT_FILE_PROD = 'docs/cashbacks.json';    // Served via the product website for end-users
 
@@ -62,6 +63,14 @@ if (argv.deal) {
  * Converts a folder of raw html files into a single json file.
  */
 function parseCashbacks() {
+
+  // First, load any predefined fixed cashback offers (e.g. Amazon cashback)
+  let fixedCashbackData = fs.readFileSync(CASHBACK_INPUT_FILE, 'utf8');
+  console.log('Found fixed cashback offers file',CASHBACK_INPUT_FILE);
+
+  for(let offer of JSON.parse(fixedCashbackData)) {
+    cashbacks.push(offer);
+  }
 
   // Find all raw HTMLs from folder
   fs.readdirSync(CASHBACK_INPUT_FOLDER).forEach(file => {


### PR DESCRIPTION
First open source pull request that addresses issue #11

Added a file named `fixedInputData.json` in `/data/cashback/` for future developers to specify additional fixed cashback offers that might come up. This still has to follow the schema as defined in the cashback schema file. Currently only has Amazon available, since that was mentioned specifically in the issue. 

One thing I chose to ignore was that due to the way dataProcessor.js handles google search queueing, a search will be performed for user-defined cashback offers as well. I could modify this with a moderate refactor of how searching/search callbacks are handled, but since this file isn't likely to be very large, I left it as is. 

Let me know if anything needs work :)

