### PR TITLE
Removing unnecessary suffixes

### DIFF
--- a/data/cashback/data.json
+++ b/data/cashback/data.json
@@ -469,7 +469,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP471",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP471.gif",
-    "site_name": "Hotels.com"
+    "site_name": "Hotels"
   },
   {
     "site_url": "www.ihop.com",

--- a/data/cashback/data.json
+++ b/data/cashback/data.json
@@ -161,7 +161,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP442",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP442.gif",
-    "site_name": "Bass Pro Shops - Featured"
+    "site_name": "Bass Pro Shops"
   },
   {
     "site_url": "www.blackangus.com",
@@ -218,7 +218,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP053",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP053.gif",
-    "site_name": "Buca di Beppo®"
+    "site_name": "Buca di Beppo"
   },
   {
     "site_url": "www.buffalowildwings.com",
@@ -273,7 +273,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP422",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP422.gif",
-    "site_name": "Chilis - Special"
+    "site_name": "Chilis"
   },
   {
     "site_url": "www.chipotle.com",
@@ -309,7 +309,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP448",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP448.gif",
-    "site_name": "Cracker Barrel Old Country - Special"
+    "site_name": "Cracker Barrel Old Country"
   },
   {
     "site_url": "www.crutchfield.com",
@@ -554,7 +554,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP174",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP174.gif",
-    "site_name": "LongHorn Steakhouse®"
+    "site_name": "LongHorn Steakhouse"
   },
   {
     "site_url": "www.lowes.com",
@@ -603,13 +603,13 @@
     "site_name": "Morton's"
   },
   {
-    "site_url": "www.eatdrinkdeals.com",
+    "site_url": "www.maggianos.com",
     "offers": [
       "$20 gets you $25"
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP424",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP424.gif",
-    "site_name": "Maggiano's - Special"
+    "site_name": "Maggiano's"
   },
   {
     "site_url": "www.neimanmarcus.com",
@@ -680,13 +680,13 @@
     "site_name": "Outback Steakhouse"
   },
   {
-    "site_url": "www.eatdrinkdeals.com",
+    "site_url": "www.ontheborder.com",
     "offers": [
       "$20 gets you $25"
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP426",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP426.gif",
-    "site_name": "On The Border - Special"
+    "site_name": "On The Border"
   },
   {
     "site_url": "www.overstock.com",
@@ -695,7 +695,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP207",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP207.gif",
-    "site_name": "Overstock.com"
+    "site_name": "Overstock"
   },
   {
     "site_url": "www.pfchangs.com",
@@ -788,7 +788,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP490",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP490.gif",
-    "site_name": "Red Lobster®"
+    "site_name": "Red Lobster"
   },
   {
     "site_url": "www.redrobin.com",
@@ -842,7 +842,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP412",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP412.gif",
-    "site_name": "Seasons 52®"
+    "site_name": "Seasons 52"
   },
   {
     "site_url": "www.sephora.com",
@@ -939,7 +939,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP126",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP126.gif",
-    "site_name": "TGI Fridays™"
+    "site_name": "TGI Fridays"
   },
   {
     "site_url": "www.thecheesecakefactory.com",
@@ -1014,7 +1014,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP390",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP390.gif",
-    "site_name": "Whole Foods Market®"
+    "site_name": "Whole Foods Market"
   },
   {
     "site_url": "www.williams-sonoma.com",
@@ -1033,7 +1033,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP413",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP413.gif",
-    "site_name": "Yard House®"
+    "site_name": "Yard House"
   },
   {
     "site_url": "www.zappos.com",

--- a/data/cashback/data.json
+++ b/data/cashback/data.json
@@ -161,7 +161,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP442",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP442.gif",
-    "site_name": "Bass Pro Shops"
+    "site_name": "Bass Pro Shops - Featured"
   },
   {
     "site_url": "www.blackangus.com",
@@ -218,7 +218,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP053",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP053.gif",
-    "site_name": "Buca di Beppo"
+    "site_name": "Buca di Beppo®"
   },
   {
     "site_url": "www.buffalowildwings.com",
@@ -273,7 +273,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP422",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP422.gif",
-    "site_name": "Chilis"
+    "site_name": "Chilis - Special"
   },
   {
     "site_url": "www.chipotle.com",
@@ -309,7 +309,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP448",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP448.gif",
-    "site_name": "Cracker Barrel Old Country"
+    "site_name": "Cracker Barrel Old Country - Special"
   },
   {
     "site_url": "www.crutchfield.com",
@@ -554,7 +554,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP174",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP174.gif",
-    "site_name": "LongHorn Steakhouse"
+    "site_name": "LongHorn Steakhouse®"
   },
   {
     "site_url": "www.lowes.com",
@@ -603,13 +603,13 @@
     "site_name": "Morton's"
   },
   {
-    "site_url": "www.maggianos.com",
+    "site_url": "www.eatdrinkdeals.com",
     "offers": [
       "$20 gets you $25"
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP424",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP424.gif",
-    "site_name": "Maggiano's"
+    "site_name": "Maggiano's - Special"
   },
   {
     "site_url": "www.neimanmarcus.com",
@@ -680,13 +680,13 @@
     "site_name": "Outback Steakhouse"
   },
   {
-    "site_url": "www.ontheborder.com",
+    "site_url": "www.eatdrinkdeals.com",
     "offers": [
       "$20 gets you $25"
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP426",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP426.gif",
-    "site_name": "On The Border"
+    "site_name": "On The Border - Special"
   },
   {
     "site_url": "www.overstock.com",
@@ -695,7 +695,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP207",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP207.gif",
-    "site_name": "Overstock"
+    "site_name": "Overstock.com"
   },
   {
     "site_url": "www.pfchangs.com",
@@ -788,7 +788,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP490",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP490.gif",
-    "site_name": "Red Lobster"
+    "site_name": "Red Lobster®"
   },
   {
     "site_url": "www.redrobin.com",
@@ -842,7 +842,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP412",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP412.gif",
-    "site_name": "Seasons 52"
+    "site_name": "Seasons 52®"
   },
   {
     "site_url": "www.sephora.com",
@@ -939,7 +939,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP126",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP126.gif",
-    "site_name": "TGI Fridays"
+    "site_name": "TGI Fridays™"
   },
   {
     "site_url": "www.thecheesecakefactory.com",
@@ -1014,7 +1014,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP390",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP390.gif",
-    "site_name": "Whole Foods Market"
+    "site_name": "Whole Foods Market®"
   },
   {
     "site_url": "www.williams-sonoma.com",
@@ -1033,7 +1033,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP413",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP413.gif",
-    "site_name": "Yard House"
+    "site_name": "Yard House®"
   },
   {
     "site_url": "www.zappos.com",

--- a/data/cashback/data.json
+++ b/data/cashback/data.json
@@ -161,7 +161,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP442",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP442.gif",
-    "site_name": "Bass Pro Shops - Featured"
+    "site_name": "Bass Pro Shops"
   },
   {
     "site_url": "www.blackangus.com",
@@ -218,7 +218,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP053",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP053.gif",
-    "site_name": "Buca di Beppo®"
+    "site_name": "Buca di Beppo"
   },
   {
     "site_url": "www.buffalowildwings.com",
@@ -273,7 +273,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP422",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP422.gif",
-    "site_name": "Chilis - Special"
+    "site_name": "Chilis"
   },
   {
     "site_url": "www.chipotle.com",
@@ -309,7 +309,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP448",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP448.gif",
-    "site_name": "Cracker Barrel Old Country - Special"
+    "site_name": "Cracker Barrel Old Country"
   },
   {
     "site_url": "www.crutchfield.com",
@@ -554,7 +554,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP174",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP174.gif",
-    "site_name": "LongHorn Steakhouse®"
+    "site_name": "LongHorn Steakhouse"
   },
   {
     "site_url": "www.lowes.com",
@@ -609,7 +609,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP424",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP424.gif",
-    "site_name": "Maggiano's - Special"
+    "site_name": "Maggiano's"
   },
   {
     "site_url": "www.neimanmarcus.com",
@@ -686,7 +686,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP426",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP426.gif",
-    "site_name": "On The Border - Special"
+    "site_name": "On The Border"
   },
   {
     "site_url": "www.overstock.com",
@@ -695,7 +695,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP207",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP207.gif",
-    "site_name": "Overstock.com"
+    "site_name": "Overstock"
   },
   {
     "site_url": "www.pfchangs.com",
@@ -707,7 +707,7 @@
     "site_name": "P.F. Chang's China Bistro"
   },
   {
-    "site_url": "panerabread.com",
+    "site_url": "www.panerabread.com",
     "offers": [
       "$45 gets you $50"
     ],
@@ -788,7 +788,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP490",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP490.gif",
-    "site_name": "Red Lobster®"
+    "site_name": "Red Lobster"
   },
   {
     "site_url": "www.redrobin.com",
@@ -842,7 +842,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP412",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP412.gif",
-    "site_name": "Seasons 52®"
+    "site_name": "Seasons 52"
   },
   {
     "site_url": "www.sephora.com",
@@ -939,7 +939,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP126",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP126.gif",
-    "site_name": "TGI Fridays™"
+    "site_name": "TGI Fridays"
   },
   {
     "site_url": "www.thecheesecakefactory.com",
@@ -1014,7 +1014,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP390",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP390.gif",
-    "site_name": "Whole Foods Market®"
+    "site_name": "Whole Foods Market"
   },
   {
     "site_url": "www.williams-sonoma.com",
@@ -1033,7 +1033,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP413",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP413.gif",
-    "site_name": "Yard House®"
+    "site_name": "Yard House"
   },
   {
     "site_url": "www.zappos.com",

--- a/data/deal/data.json
+++ b/data/deal/data.json
@@ -17,7 +17,7 @@
   },
   {
     "title": "20% off one regularly priced small appliance, BestBuy.com®",
-    "site_name": "BestBuy.com®",
+    "site_name": "BestBuy",
     "site_url": "www.bestbuy.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10552",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9145_big_01272016.jpg",
@@ -34,7 +34,7 @@
   {
     "title": "Get up to 25% off select PCs, Lenovo",
     "site_name": "Lenovo",
-    "site_url": "www3.lenovo.com",
+    "site_url": "www.lenovo.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10600",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_10600_big_11292017.jpg",
     "expiry_date": "Expires 06/30/2018"
@@ -73,7 +73,7 @@
   },
   {
     "title": "Get 20% off a purchase, 1800Flowers.com",
-    "site_name": "1800Flowers.com",
+    "site_name": "1800Flowers",
     "site_url": "www.1800flowers.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10698",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_6115_big_12112014.jpg",
@@ -529,7 +529,7 @@
   },
   {
     "title": "Get up to $150 in onboard credits through Cruise & Vacation Desk, Disney Cruise Line®",
-    "site_name": "Disney Cruise Line®",
+    "site_name": "Disney Cruise Line",
     "site_url": "disneycruise.disney.go.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10715",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_10715_big_01312018.jpg",
@@ -618,7 +618,7 @@
   {
     "title": "Earn 5% Cashback Bonus through Cruise & Vacation Desk, Hard Rock Resorts Mexico",
     "site_name": "Hard Rock Resorts Mexico",
-    "site_url": "www.hardrockhotels.com",
+    "site_url": "www.hrhrivieramaya.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10640",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_10640_big_12072017.jpg",
     "expiry_date": "Expires 12/31/2018"
@@ -850,7 +850,7 @@
   {
     "title": "30% off, Budget Blinds",
     "site_name": "Budget Blinds",
-    "site_url": "www.budgetblinds.com",
+    "site_url": "budgetblinds.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10030",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9773_big_11042016.jpg",
     "expiry_date": "Expires 06/30/2018"
@@ -898,7 +898,7 @@
   {
     "title": "Get $10 off a purchase of $60 or more, Van Heusen",
     "site_name": "Van Heusen",
-    "site_url": "vanheusen.com",
+    "site_url": "vanheusen.partnerbrands.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10738",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_6001_big_12042014.jpg",
     "expiry_date": "Expires 12/31/2018"
@@ -937,7 +937,7 @@
   },
   {
     "title": "Get 20% off a purchase, FragranceNet.com",
-    "site_name": "FragranceNet.com",
+    "site_name": "FragranceNet",
     "site_url": "www.fragrancenet.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10695",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9532_big_07082016.jpg",
@@ -953,7 +953,7 @@
   },
   {
     "title": "Get 10% off any purchase, Shop.NHL.com",
-    "site_name": "Shop.NHL.com",
+    "site_name": "Shop.NHL",
     "site_url": "shop.nhl.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10847",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_5471_big_10282014.jpg",
@@ -1057,7 +1057,7 @@
   },
   {
     "title": "Get 20% off a purchase, 1800Baskets.com",
-    "site_name": "1800Baskets.com",
+    "site_name": "1800Baskets",
     "site_url": "www.1800baskets.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10699",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9832_big_11162016.jpg",
@@ -1097,7 +1097,7 @@
   },
   {
     "title": "Get 20% off a purchase, Fruitbouquets.com",
-    "site_name": "Fruitbouquets.com",
+    "site_name": "Fruitbouquets",
     "site_url": "www.fruitbouquets.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10701",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_8690_big_10092015.jpg",

--- a/data/deal/data.json
+++ b/data/deal/data.json
@@ -169,7 +169,7 @@
   },
   {
     "title": "Get 5% off select hotels, Hotels.com",
-    "site_name": "Hotels.com",
+    "site_name": "Hotels",
     "site_url": "www.hotels.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10680",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_6577_big_01272015.jpg",

--- a/data/deal/data.json
+++ b/data/deal/data.json
@@ -17,7 +17,7 @@
   },
   {
     "title": "20% off one regularly priced small appliance, BestBuy.com®",
-    "site_name": "BestBuy.com®",
+    "site_name": "BestBuy",
     "site_url": "www.bestbuy.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10552",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9145_big_01272016.jpg",
@@ -73,7 +73,7 @@
   },
   {
     "title": "Get 20% off a purchase, 1800Flowers.com",
-    "site_name": "1800Flowers.com",
+    "site_name": "1800Flowers",
     "site_url": "www.1800flowers.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10698",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_6115_big_12112014.jpg",
@@ -529,7 +529,7 @@
   },
   {
     "title": "Get up to $150 in onboard credits through Cruise & Vacation Desk, Disney Cruise Line®",
-    "site_name": "Disney Cruise Line®",
+    "site_name": "Disney Cruise Line",
     "site_url": "disneycruise.disney.go.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10715",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_10715_big_01312018.jpg",
@@ -937,7 +937,7 @@
   },
   {
     "title": "Get 20% off a purchase, FragranceNet.com",
-    "site_name": "FragranceNet.com",
+    "site_name": "FragranceNet",
     "site_url": "www.fragrancenet.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10695",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9532_big_07082016.jpg",
@@ -953,7 +953,7 @@
   },
   {
     "title": "Get 10% off any purchase, Shop.NHL.com",
-    "site_name": "Shop.NHL.com",
+    "site_name": "Shop.NHL",
     "site_url": "shop.nhl.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10847",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_5471_big_10282014.jpg",
@@ -1057,7 +1057,7 @@
   },
   {
     "title": "Get 20% off a purchase, 1800Baskets.com",
-    "site_name": "1800Baskets.com",
+    "site_name": "1800Baskets",
     "site_url": "www.1800baskets.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10699",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9832_big_11162016.jpg",
@@ -1097,7 +1097,7 @@
   },
   {
     "title": "Get 20% off a purchase, Fruitbouquets.com",
-    "site_name": "Fruitbouquets.com",
+    "site_name": "Fruitbouquets",
     "site_url": "www.fruitbouquets.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10701",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_8690_big_10092015.jpg",

--- a/data/deal/data.json
+++ b/data/deal/data.json
@@ -17,7 +17,7 @@
   },
   {
     "title": "20% off one regularly priced small appliance, BestBuy.com®",
-    "site_name": "BestBuy",
+    "site_name": "BestBuy.com®",
     "site_url": "www.bestbuy.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10552",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9145_big_01272016.jpg",
@@ -73,7 +73,7 @@
   },
   {
     "title": "Get 20% off a purchase, 1800Flowers.com",
-    "site_name": "1800Flowers",
+    "site_name": "1800Flowers.com",
     "site_url": "www.1800flowers.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10698",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_6115_big_12112014.jpg",
@@ -529,7 +529,7 @@
   },
   {
     "title": "Get up to $150 in onboard credits through Cruise & Vacation Desk, Disney Cruise Line®",
-    "site_name": "Disney Cruise Line",
+    "site_name": "Disney Cruise Line®",
     "site_url": "disneycruise.disney.go.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10715",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_10715_big_01312018.jpg",
@@ -937,7 +937,7 @@
   },
   {
     "title": "Get 20% off a purchase, FragranceNet.com",
-    "site_name": "FragranceNet",
+    "site_name": "FragranceNet.com",
     "site_url": "www.fragrancenet.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10695",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9532_big_07082016.jpg",
@@ -953,7 +953,7 @@
   },
   {
     "title": "Get 10% off any purchase, Shop.NHL.com",
-    "site_name": "Shop.NHL",
+    "site_name": "Shop.NHL.com",
     "site_url": "shop.nhl.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10847",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_5471_big_10282014.jpg",
@@ -1057,7 +1057,7 @@
   },
   {
     "title": "Get 20% off a purchase, 1800Baskets.com",
-    "site_name": "1800Baskets",
+    "site_name": "1800Baskets.com",
     "site_url": "www.1800baskets.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10699",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9832_big_11162016.jpg",
@@ -1097,7 +1097,7 @@
   },
   {
     "title": "Get 20% off a purchase, Fruitbouquets.com",
-    "site_name": "Fruitbouquets",
+    "site_name": "Fruitbouquets.com",
     "site_url": "www.fruitbouquets.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10701",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_8690_big_10092015.jpg",

--- a/docs/cashbacks.json
+++ b/docs/cashbacks.json
@@ -469,7 +469,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP471",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP471.gif",
-    "site_name": "Hotels.com"
+    "site_name": "Hotels"
   },
   {
     "site_url": "www.ihop.com",

--- a/docs/cashbacks.json
+++ b/docs/cashbacks.json
@@ -161,7 +161,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP442",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP442.gif",
-    "site_name": "Bass Pro Shops - Featured"
+    "site_name": "Bass Pro Shops"
   },
   {
     "site_url": "www.blackangus.com",
@@ -218,7 +218,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP053",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP053.gif",
-    "site_name": "Buca di Beppo®"
+    "site_name": "Buca di Beppo"
   },
   {
     "site_url": "www.buffalowildwings.com",
@@ -273,7 +273,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP422",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP422.gif",
-    "site_name": "Chilis - Special"
+    "site_name": "Chilis"
   },
   {
     "site_url": "www.chipotle.com",
@@ -309,7 +309,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP448",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP448.gif",
-    "site_name": "Cracker Barrel Old Country - Special"
+    "site_name": "Cracker Barrel Old Country"
   },
   {
     "site_url": "www.crutchfield.com",
@@ -554,7 +554,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP174",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP174.gif",
-    "site_name": "LongHorn Steakhouse®"
+    "site_name": "LongHorn Steakhouse"
   },
   {
     "site_url": "www.lowes.com",
@@ -603,13 +603,13 @@
     "site_name": "Morton's"
   },
   {
-    "site_url": "www.eatdrinkdeals.com",
+    "site_url": "www.maggianos.com",
     "offers": [
       "$20 gets you $25"
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP424",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP424.gif",
-    "site_name": "Maggiano's - Special"
+    "site_name": "Maggiano's"
   },
   {
     "site_url": "www.neimanmarcus.com",
@@ -680,13 +680,13 @@
     "site_name": "Outback Steakhouse"
   },
   {
-    "site_url": "www.eatdrinkdeals.com",
+    "site_url": "www.ontheborder.com",
     "offers": [
       "$20 gets you $25"
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP426",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP426.gif",
-    "site_name": "On The Border - Special"
+    "site_name": "On The Border"
   },
   {
     "site_url": "www.overstock.com",
@@ -695,7 +695,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP207",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP207.gif",
-    "site_name": "Overstock.com"
+    "site_name": "Overstock"
   },
   {
     "site_url": "www.pfchangs.com",
@@ -788,7 +788,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP490",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP490.gif",
-    "site_name": "Red Lobster®"
+    "site_name": "Red Lobster"
   },
   {
     "site_url": "www.redrobin.com",
@@ -842,7 +842,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP412",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP412.gif",
-    "site_name": "Seasons 52®"
+    "site_name": "Seasons 52"
   },
   {
     "site_url": "www.sephora.com",
@@ -939,7 +939,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP126",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP126.gif",
-    "site_name": "TGI Fridays™"
+    "site_name": "TGI Fridays"
   },
   {
     "site_url": "www.thecheesecakefactory.com",
@@ -1014,7 +1014,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP390",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP390.gif",
-    "site_name": "Whole Foods Market®"
+    "site_name": "Whole Foods Market"
   },
   {
     "site_url": "www.williams-sonoma.com",
@@ -1033,7 +1033,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP413",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP413.gif",
-    "site_name": "Yard House®"
+    "site_name": "Yard House"
   },
   {
     "site_url": "www.zappos.com",

--- a/docs/cashbacks.json
+++ b/docs/cashbacks.json
@@ -161,7 +161,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP442",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP442.gif",
-    "site_name": "Bass Pro Shops"
+    "site_name": "Bass Pro Shops - Featured"
   },
   {
     "site_url": "www.blackangus.com",
@@ -218,7 +218,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP053",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP053.gif",
-    "site_name": "Buca di Beppo"
+    "site_name": "Buca di Beppo®"
   },
   {
     "site_url": "www.buffalowildwings.com",
@@ -273,7 +273,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP422",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP422.gif",
-    "site_name": "Chilis"
+    "site_name": "Chilis - Special"
   },
   {
     "site_url": "www.chipotle.com",
@@ -309,7 +309,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP448",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP448.gif",
-    "site_name": "Cracker Barrel Old Country"
+    "site_name": "Cracker Barrel Old Country - Special"
   },
   {
     "site_url": "www.crutchfield.com",
@@ -554,7 +554,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP174",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP174.gif",
-    "site_name": "LongHorn Steakhouse"
+    "site_name": "LongHorn Steakhouse®"
   },
   {
     "site_url": "www.lowes.com",
@@ -603,13 +603,13 @@
     "site_name": "Morton's"
   },
   {
-    "site_url": "www.maggianos.com",
+    "site_url": "www.eatdrinkdeals.com",
     "offers": [
       "$20 gets you $25"
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP424",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP424.gif",
-    "site_name": "Maggiano's"
+    "site_name": "Maggiano's - Special"
   },
   {
     "site_url": "www.neimanmarcus.com",
@@ -680,13 +680,13 @@
     "site_name": "Outback Steakhouse"
   },
   {
-    "site_url": "www.ontheborder.com",
+    "site_url": "www.eatdrinkdeals.com",
     "offers": [
       "$20 gets you $25"
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP426",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP426.gif",
-    "site_name": "On The Border"
+    "site_name": "On The Border - Special"
   },
   {
     "site_url": "www.overstock.com",
@@ -695,7 +695,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP207",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP207.gif",
-    "site_name": "Overstock"
+    "site_name": "Overstock.com"
   },
   {
     "site_url": "www.pfchangs.com",
@@ -788,7 +788,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP490",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP490.gif",
-    "site_name": "Red Lobster"
+    "site_name": "Red Lobster®"
   },
   {
     "site_url": "www.redrobin.com",
@@ -842,7 +842,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP412",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP412.gif",
-    "site_name": "Seasons 52"
+    "site_name": "Seasons 52®"
   },
   {
     "site_url": "www.sephora.com",
@@ -939,7 +939,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP126",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP126.gif",
-    "site_name": "TGI Fridays"
+    "site_name": "TGI Fridays™"
   },
   {
     "site_url": "www.thecheesecakefactory.com",
@@ -1014,7 +1014,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP390",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP390.gif",
-    "site_name": "Whole Foods Market"
+    "site_name": "Whole Foods Market®"
   },
   {
     "site_url": "www.williams-sonoma.com",
@@ -1033,7 +1033,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP413",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP413.gif",
-    "site_name": "Yard House"
+    "site_name": "Yard House®"
   },
   {
     "site_url": "www.zappos.com",

--- a/docs/cashbacks.json
+++ b/docs/cashbacks.json
@@ -161,7 +161,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP442",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP442.gif",
-    "site_name": "Bass Pro Shops - Featured"
+    "site_name": "Bass Pro Shops"
   },
   {
     "site_url": "www.blackangus.com",
@@ -218,7 +218,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP053",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP053.gif",
-    "site_name": "Buca di Beppo®"
+    "site_name": "Buca di Beppo"
   },
   {
     "site_url": "www.buffalowildwings.com",
@@ -273,7 +273,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP422",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP422.gif",
-    "site_name": "Chilis - Special"
+    "site_name": "Chilis"
   },
   {
     "site_url": "www.chipotle.com",
@@ -309,7 +309,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP448",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP448.gif",
-    "site_name": "Cracker Barrel Old Country - Special"
+    "site_name": "Cracker Barrel Old Country"
   },
   {
     "site_url": "www.crutchfield.com",
@@ -554,7 +554,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP174",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP174.gif",
-    "site_name": "LongHorn Steakhouse®"
+    "site_name": "LongHorn Steakhouse"
   },
   {
     "site_url": "www.lowes.com",
@@ -609,7 +609,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP424",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP424.gif",
-    "site_name": "Maggiano's - Special"
+    "site_name": "Maggiano's"
   },
   {
     "site_url": "www.neimanmarcus.com",
@@ -686,7 +686,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP426",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP426.gif",
-    "site_name": "On The Border - Special"
+    "site_name": "On The Border"
   },
   {
     "site_url": "www.overstock.com",
@@ -695,7 +695,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP207",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP207.gif",
-    "site_name": "Overstock.com"
+    "site_name": "Overstock"
   },
   {
     "site_url": "www.pfchangs.com",
@@ -707,7 +707,7 @@
     "site_name": "P.F. Chang's China Bistro"
   },
   {
-    "site_url": "panerabread.com",
+    "site_url": "www.panerabread.com",
     "offers": [
       "$45 gets you $50"
     ],
@@ -788,7 +788,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP490",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP490.gif",
-    "site_name": "Red Lobster®"
+    "site_name": "Red Lobster"
   },
   {
     "site_url": "www.redrobin.com",
@@ -842,7 +842,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP412",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP412.gif",
-    "site_name": "Seasons 52®"
+    "site_name": "Seasons 52"
   },
   {
     "site_url": "www.sephora.com",
@@ -939,7 +939,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP126",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP126.gif",
-    "site_name": "TGI Fridays™"
+    "site_name": "TGI Fridays"
   },
   {
     "site_url": "www.thecheesecakefactory.com",
@@ -1014,7 +1014,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP390",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP390.gif",
-    "site_name": "Whole Foods Market®"
+    "site_name": "Whole Foods Market"
   },
   {
     "site_url": "www.williams-sonoma.com",
@@ -1033,7 +1033,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP413",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP413.gif",
-    "site_name": "Yard House®"
+    "site_name": "Yard House"
   },
   {
     "site_url": "www.zappos.com",

--- a/docs/deals.json
+++ b/docs/deals.json
@@ -17,7 +17,7 @@
   },
   {
     "title": "20% off one regularly priced small appliance, BestBuy.com®",
-    "site_name": "BestBuy.com®",
+    "site_name": "BestBuy",
     "site_url": "www.bestbuy.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10552",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9145_big_01272016.jpg",
@@ -34,7 +34,7 @@
   {
     "title": "Get up to 25% off select PCs, Lenovo",
     "site_name": "Lenovo",
-    "site_url": "www3.lenovo.com",
+    "site_url": "www.lenovo.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10600",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_10600_big_11292017.jpg",
     "expiry_date": "Expires 06/30/2018"
@@ -73,7 +73,7 @@
   },
   {
     "title": "Get 20% off a purchase, 1800Flowers.com",
-    "site_name": "1800Flowers.com",
+    "site_name": "1800Flowers",
     "site_url": "www.1800flowers.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10698",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_6115_big_12112014.jpg",
@@ -529,7 +529,7 @@
   },
   {
     "title": "Get up to $150 in onboard credits through Cruise & Vacation Desk, Disney Cruise Line®",
-    "site_name": "Disney Cruise Line®",
+    "site_name": "Disney Cruise Line",
     "site_url": "disneycruise.disney.go.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10715",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_10715_big_01312018.jpg",
@@ -618,7 +618,7 @@
   {
     "title": "Earn 5% Cashback Bonus through Cruise & Vacation Desk, Hard Rock Resorts Mexico",
     "site_name": "Hard Rock Resorts Mexico",
-    "site_url": "www.hardrockhotels.com",
+    "site_url": "www.hrhrivieramaya.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10640",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_10640_big_12072017.jpg",
     "expiry_date": "Expires 12/31/2018"
@@ -850,7 +850,7 @@
   {
     "title": "30% off, Budget Blinds",
     "site_name": "Budget Blinds",
-    "site_url": "www.budgetblinds.com",
+    "site_url": "budgetblinds.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10030",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9773_big_11042016.jpg",
     "expiry_date": "Expires 06/30/2018"
@@ -898,7 +898,7 @@
   {
     "title": "Get $10 off a purchase of $60 or more, Van Heusen",
     "site_name": "Van Heusen",
-    "site_url": "vanheusen.com",
+    "site_url": "vanheusen.partnerbrands.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10738",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_6001_big_12042014.jpg",
     "expiry_date": "Expires 12/31/2018"
@@ -937,7 +937,7 @@
   },
   {
     "title": "Get 20% off a purchase, FragranceNet.com",
-    "site_name": "FragranceNet.com",
+    "site_name": "FragranceNet",
     "site_url": "www.fragrancenet.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10695",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9532_big_07082016.jpg",
@@ -953,7 +953,7 @@
   },
   {
     "title": "Get 10% off any purchase, Shop.NHL.com",
-    "site_name": "Shop.NHL.com",
+    "site_name": "Shop.NHL",
     "site_url": "shop.nhl.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10847",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_5471_big_10282014.jpg",
@@ -1057,7 +1057,7 @@
   },
   {
     "title": "Get 20% off a purchase, 1800Baskets.com",
-    "site_name": "1800Baskets.com",
+    "site_name": "1800Baskets",
     "site_url": "www.1800baskets.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10699",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9832_big_11162016.jpg",
@@ -1097,7 +1097,7 @@
   },
   {
     "title": "Get 20% off a purchase, Fruitbouquets.com",
-    "site_name": "Fruitbouquets.com",
+    "site_name": "Fruitbouquets",
     "site_url": "www.fruitbouquets.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10701",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_8690_big_10092015.jpg",

--- a/docs/deals.json
+++ b/docs/deals.json
@@ -169,7 +169,7 @@
   },
   {
     "title": "Get 5% off select hotels, Hotels.com",
-    "site_name": "Hotels.com",
+    "site_name": "Hotels",
     "site_url": "www.hotels.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10680",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_6577_big_01272015.jpg",

--- a/docs/deals.json
+++ b/docs/deals.json
@@ -17,7 +17,7 @@
   },
   {
     "title": "20% off one regularly priced small appliance, BestBuy.com®",
-    "site_name": "BestBuy.com®",
+    "site_name": "BestBuy",
     "site_url": "www.bestbuy.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10552",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9145_big_01272016.jpg",
@@ -73,7 +73,7 @@
   },
   {
     "title": "Get 20% off a purchase, 1800Flowers.com",
-    "site_name": "1800Flowers.com",
+    "site_name": "1800Flowers",
     "site_url": "www.1800flowers.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10698",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_6115_big_12112014.jpg",
@@ -529,7 +529,7 @@
   },
   {
     "title": "Get up to $150 in onboard credits through Cruise & Vacation Desk, Disney Cruise Line®",
-    "site_name": "Disney Cruise Line®",
+    "site_name": "Disney Cruise Line",
     "site_url": "disneycruise.disney.go.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10715",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_10715_big_01312018.jpg",
@@ -937,7 +937,7 @@
   },
   {
     "title": "Get 20% off a purchase, FragranceNet.com",
-    "site_name": "FragranceNet.com",
+    "site_name": "FragranceNet",
     "site_url": "www.fragrancenet.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10695",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9532_big_07082016.jpg",
@@ -953,7 +953,7 @@
   },
   {
     "title": "Get 10% off any purchase, Shop.NHL.com",
-    "site_name": "Shop.NHL.com",
+    "site_name": "Shop.NHL",
     "site_url": "shop.nhl.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10847",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_5471_big_10282014.jpg",
@@ -1057,7 +1057,7 @@
   },
   {
     "title": "Get 20% off a purchase, 1800Baskets.com",
-    "site_name": "1800Baskets.com",
+    "site_name": "1800Baskets",
     "site_url": "www.1800baskets.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10699",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9832_big_11162016.jpg",
@@ -1097,7 +1097,7 @@
   },
   {
     "title": "Get 20% off a purchase, Fruitbouquets.com",
-    "site_name": "Fruitbouquets.com",
+    "site_name": "Fruitbouquets",
     "site_url": "www.fruitbouquets.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10701",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_8690_big_10092015.jpg",

--- a/docs/deals.json
+++ b/docs/deals.json
@@ -17,7 +17,7 @@
   },
   {
     "title": "20% off one regularly priced small appliance, BestBuy.com®",
-    "site_name": "BestBuy",
+    "site_name": "BestBuy.com®",
     "site_url": "www.bestbuy.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10552",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9145_big_01272016.jpg",
@@ -73,7 +73,7 @@
   },
   {
     "title": "Get 20% off a purchase, 1800Flowers.com",
-    "site_name": "1800Flowers",
+    "site_name": "1800Flowers.com",
     "site_url": "www.1800flowers.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10698",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_6115_big_12112014.jpg",
@@ -529,7 +529,7 @@
   },
   {
     "title": "Get up to $150 in onboard credits through Cruise & Vacation Desk, Disney Cruise Line®",
-    "site_name": "Disney Cruise Line",
+    "site_name": "Disney Cruise Line®",
     "site_url": "disneycruise.disney.go.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10715",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_10715_big_01312018.jpg",
@@ -937,7 +937,7 @@
   },
   {
     "title": "Get 20% off a purchase, FragranceNet.com",
-    "site_name": "FragranceNet",
+    "site_name": "FragranceNet.com",
     "site_url": "www.fragrancenet.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10695",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9532_big_07082016.jpg",
@@ -953,7 +953,7 @@
   },
   {
     "title": "Get 10% off any purchase, Shop.NHL.com",
-    "site_name": "Shop.NHL",
+    "site_name": "Shop.NHL.com",
     "site_url": "shop.nhl.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10847",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_5471_big_10282014.jpg",
@@ -1057,7 +1057,7 @@
   },
   {
     "title": "Get 20% off a purchase, 1800Baskets.com",
-    "site_name": "1800Baskets",
+    "site_name": "1800Baskets.com",
     "site_url": "www.1800baskets.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10699",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_9832_big_11162016.jpg",
@@ -1097,7 +1097,7 @@
   },
   {
     "title": "Get 20% off a purchase, Fruitbouquets.com",
-    "site_name": "Fruitbouquets",
+    "site_name": "Fruitbouquets.com",
     "site_url": "www.fruitbouquets.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10701",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_8690_big_10092015.jpg",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "dev": true,
       "requires": {
         "kind-of": "3.2.2",
         "longest": "1.0.1",
@@ -35,7 +36,8 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
     },
     "ansi-regex": {
       "version": "3.0.0",
@@ -58,7 +60,8 @@
     "async": {
       "version": "1.5.2",
       "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -119,6 +122,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4",
@@ -238,7 +242,8 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "dev": true
     },
     "delayed-stream": {
       "version": "1.0.0",
@@ -533,6 +538,7 @@
       "version": "4.0.11",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.11.tgz",
       "integrity": "sha1-Ywo13+ApS8KB7a5v/F0yn8eYLcw=",
+      "dev": true,
       "requires": {
         "async": "1.5.2",
         "optimist": "0.6.1",
@@ -614,7 +620,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -708,6 +715,7 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "dev": true,
       "requires": {
         "is-buffer": "1.1.6"
       }
@@ -716,6 +724,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+      "dev": true,
       "optional": true
     },
     "lcid": {
@@ -746,7 +755,8 @@
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
-      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.1",
@@ -791,7 +801,8 @@
     "minimist": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+      "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+      "dev": true
     },
     "npm-run-path": {
       "version": "2.0.2",
@@ -827,6 +838,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.10",
         "wordwrap": "0.0.3"
@@ -960,7 +972,8 @@
     "repeat-string": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+      "dev": true
     },
     "request": {
       "version": "2.83.0",
@@ -1008,6 +1021,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "dev": true,
       "optional": true,
       "requires": {
         "align-text": "0.1.4"
@@ -1059,6 +1073,7 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
       "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "dev": true,
       "requires": {
         "amdefine": "1.0.1"
       }
@@ -1148,6 +1163,7 @@
       "version": "2.8.29",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
+      "dev": true,
       "optional": true,
       "requires": {
         "source-map": "0.5.7",
@@ -1159,12 +1175,14 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
           "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+          "dev": true,
           "optional": true
         },
         "cliui": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
           "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+          "dev": true,
           "optional": true,
           "requires": {
             "center-align": "0.1.3",
@@ -1176,18 +1194,21 @@
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
           "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+          "dev": true,
           "optional": true
         },
         "wordwrap": {
           "version": "0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
           "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+          "dev": true,
           "optional": true
         },
         "yargs": {
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+          "dev": true,
           "optional": true,
           "requires": {
             "camelcase": "1.2.1",
@@ -1202,6 +1223,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
       "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+      "dev": true,
       "optional": true
     },
     "unescape": {
@@ -1255,12 +1277,14 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+      "dev": true,
       "optional": true
     },
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",

--- a/tools/dataProcessor.js
+++ b/tools/dataProcessor.js
@@ -125,7 +125,7 @@ function parseCashbacks() {
         let suffix_check = ['.com',' - Special',' - Featured','®','™' ]
 
         for(let i = 0; i < suffix_check.length; i++){
-          if (cashback.site_name .indexOf(suffix_check[i]) != -1 && cashback.site_name != 'Hotels.com') {
+          if (cashback.site_name.indexOf(suffix_check[i]) != -1 && cashback.site_name != 'Hotels.com') {
             cashback.site_name  = cashback.site_name .replace(suffix_check[i],'');
           }
       }

--- a/tools/dataProcessor.js
+++ b/tools/dataProcessor.js
@@ -122,7 +122,7 @@ function parseCashbacks() {
         cashback.site_name = imgTag.attr('title');
 
         // This removes unnecessary cashback suffixes
-        removeSuffixes(cashback.site_name);
+        cashback.site_name = removeSuffixes(cashback.site_name);
 
         // Note that the number of offers for a single item varies
         let offerTags = $(item).find('div[class="pill giftItem"]');
@@ -188,7 +188,7 @@ function parseDeals() {
     };
 
     // This removes unnecessary deal suffixes
-    removeSuffixes(deal.site_name);
+    deal.site_name = removeSuffixes(deal.site_name);
    
     // Put this deal object into the main array
     deals.push(deal);
@@ -229,7 +229,7 @@ function removeSuffixes(item) {
       item  = item.replace(suffix_check[i],'');
     }
   }
-
+  return item
 }
 
 /**

--- a/tools/dataProcessor.js
+++ b/tools/dataProcessor.js
@@ -229,7 +229,7 @@ function removeSuffixes(item) {
       item  = item.replace(suffix_check[i],'');
     }
   }
-  return item
+  return item;
 }
 
 /**

--- a/tools/dataProcessor.js
+++ b/tools/dataProcessor.js
@@ -121,14 +121,8 @@ function parseCashbacks() {
         cashback.img_src_url = 'https://card.discover.com' + imgTag.attr('src');
         cashback.site_name = imgTag.attr('title');
 
-        // Removing unnecessary cashback suffixes
-        let suffix_check = ['.com',' - Special',' - Featured','®','™' ]
-
-        for(let i = 0; i < suffix_check.length; i++){
-          if (cashback.site_name.indexOf(suffix_check[i]) != -1 && cashback.site_name != 'Hotels.com') {
-            cashback.site_name  = cashback.site_name.replace(suffix_check[i],'');
-          }
-      }
+        // This removes unnecessary cashback suffixes
+        removeSuffixes(cashback.site_name);
 
         // Note that the number of offers for a single item varies
         let offerTags = $(item).find('div[class="pill giftItem"]');
@@ -193,15 +187,9 @@ function parseDeals() {
       expiry_date: decode(xml_line.match("class=\"date\">(.*)<\\/div>")[1])
     };
 
-    // Removing unnecessary deal suffixes
-    let suffix_check = ['.com',' - Special',' - Featured','®','™' ]
-
-    for(let i = 0; i < suffix_check.length; i++){
-      if (deal.site_name.indexOf(suffix_check[i]) != -1 && deal.site_name != 'Hotels.com') {
-        deal.site_name  = deal.site_name .replace(suffix_check[i],'');
-      }
-    }
-
+    // This removes unnecessary deal suffixes
+    removeSuffixes(deal.site_name);
+   
     // Put this deal object into the main array
     deals.push(deal);
   }
@@ -225,6 +213,21 @@ function parseDeals() {
 
     // Keep googling as there's more deals left
     googleSearch(deals[index].site_name, onGoogleDeal);
+  }
+
+}
+
+/**
+ * Removes unnecessary suffixes from a site's name
+ * Does this by checking an array of ignored suffixes and replacing with an empty string.
+ */
+function removeSuffixes(item) {
+  let suffix_check = ['.com',' - Special',' - Featured','®','™' ];
+
+  for(let i = 0; i < suffix_check.length; i++){
+    if (item.indexOf(suffix_check[i]) != -1 && item != 'Hotels.com') {
+      item  = item.replace(suffix_check[i],'');
+    }
   }
 
 }

--- a/tools/dataProcessor.js
+++ b/tools/dataProcessor.js
@@ -222,11 +222,17 @@ function parseDeals() {
  * Does this by checking an array of ignored suffixes and replacing with an empty string.
  */
 function removeSuffixes(item) {
+  
+  // Suffixes to remove
   let suffix_check = ['.com',' - Special',' - Featured','®','™' ];
+  
+  // Names that require their suffix
+  let ignored_names = ['Hotels.com'];
 
+  // Removing suffixes
   for(let i = 0; i < suffix_check.length; i++){
-    if (item.indexOf(suffix_check[i]) != -1 && item != 'Hotels.com') {
-      item  = item.replace(suffix_check[i],'');
+    if (item.indexOf(suffix_check[i]) != -1 && ignored_names.indexOf(item.site_name) == -1) {
+      item = item.replace(suffix_check[i],'');
     }
   }
   return item;

--- a/tools/dataProcessor.js
+++ b/tools/dataProcessor.js
@@ -126,7 +126,7 @@ function parseCashbacks() {
 
         for(let i = 0; i < suffix_check.length; i++){
           if (cashback.site_name.indexOf(suffix_check[i]) != -1 && cashback.site_name != 'Hotels.com') {
-            cashback.site_name  = cashback.site_name .replace(suffix_check[i],'');
+            cashback.site_name  = cashback.site_name.replace(suffix_check[i],'');
           }
       }
 

--- a/tools/dataProcessor.js
+++ b/tools/dataProcessor.js
@@ -121,6 +121,15 @@ function parseCashbacks() {
         cashback.img_src_url = 'https://card.discover.com' + imgTag.attr('src');
         cashback.site_name = imgTag.attr('title');
 
+        // Removing unnecessary cashback suffixes
+        let suffix_check = ['.com',' - Special',' - Featured','®','™' ]
+
+        for(let i = 0; i < suffix_check.length; i++){
+          if (cashback.site_name .indexOf(suffix_check[i]) != -1 && cashback.site_name != 'Hotels.com') {
+            cashback.site_name  = cashback.site_name .replace(suffix_check[i],'');
+          }
+      }
+
         // Note that the number of offers for a single item varies
         let offerTags = $(item).find('div[class="pill giftItem"]');
         offerTags.each(function (index, offer) {
@@ -183,6 +192,15 @@ function parseDeals() {
       img_src_url: xml_line.match("(https:\\/\\/www.discovercard.com\\/extras.*)\" alt")[1],
       expiry_date: decode(xml_line.match("class=\"date\">(.*)<\\/div>")[1])
     };
+
+    // Removing unnecessary deal suffixes
+    let suffix_check = ['.com',' - Special',' - Featured','®','™' ]
+
+    for(let i = 0; i < suffix_check.length; i++){
+      if (deal.site_name.indexOf(suffix_check[i]) != -1 && deal.site_name != 'Hotels.com') {
+        deal.site_name  = deal.site_name .replace(suffix_check[i],'');
+      }
+    }
 
     // Put this deal object into the main array
     deals.push(deal);


### PR DESCRIPTION
Hi, I am a bit of a beginner when it comes to PRs, I hope this one looks OK!

This is a response to issue #69 

Inside the `dataProcessor.js`  script, I have created some lines of code that checks and deletes unnecessary suffixes found in the retailer name for deals & cashbacks  to enhance the google algorithm as it transforms raw data into JSON

Suffixes include: `['.com',' - Special',' - Featured','®','™' ]`
- Ex: `"Chilis - Special"` → `"Chilis"`
- Ex: `"BestBuy.com®"` → `"BestBuy"`

Some notes:
- I figured the `.com` in Hotels.com is what the company is known for, so I kept it in, unless otherwise
- Interestingly, in some of the cases where cashback/deal properties have remained unchanged, my google search may pick up different `site_url` (?)