### PR TITLE
Don't remove all suffixes on all site names

### DIFF
--- a/data/cashback/data.json
+++ b/data/cashback/data.json
@@ -469,7 +469,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP471",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP471.gif",
-    "site_name": "Hotels"
+    "site_name": "Hotels.com"
   },
   {
     "site_url": "www.ihop.com",

--- a/data/deal/data.json
+++ b/data/deal/data.json
@@ -169,7 +169,7 @@
   },
   {
     "title": "Get 5% off select hotels, Hotels.com",
-    "site_name": "Hotels",
+    "site_name": "Hotels.com",
     "site_url": "www.hotels.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10680",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_6577_big_01272015.jpg",

--- a/docs/cashbacks.json
+++ b/docs/cashbacks.json
@@ -469,7 +469,7 @@
     ],
     "cashback_url": "https://card.discover.com/cardmembersvcs/rewards/app/browsePartner?modeCode=CP471",
     "img_src_url": "https://card.discover.com/discover/images/cbb/logos/large/CP471.gif",
-    "site_name": "Hotels"
+    "site_name": "Hotels.com"
   },
   {
     "site_url": "www.ihop.com",

--- a/docs/deals.json
+++ b/docs/deals.json
@@ -169,7 +169,7 @@
   },
   {
     "title": "Get 5% off select hotels, Hotels.com",
-    "site_name": "Hotels",
+    "site_name": "Hotels.com",
     "site_url": "www.hotels.com",
     "deal_url": "https://card.discover.com/cardmembersvcs/deals/app/home#/deal/10680",
     "img_src_url": "https://www.discovercard.com/extras/logo/large/offer_6577_big_01272015.jpg",

--- a/tools/dataProcessor.js
+++ b/tools/dataProcessor.js
@@ -221,21 +221,21 @@ function parseDeals() {
  * Removes unnecessary suffixes from a site's name
  * Does this by checking an array of ignored suffixes and replacing with an empty string.
  */
-function removeSuffixes(item) {
-  
+function removeSuffixes(itemName) {
+
   // Suffixes to remove
-  let suffix_check = ['.com',' - Special',' - Featured','®','™' ];
-  
+  let suffix_check = ['.com', ' - Special', ' - Featured', '®', '™'];
+
   // Names that require their suffix
   let ignored_names = ['Hotels.com'];
 
   // Removing suffixes
-  for(let i = 0; i < suffix_check.length; i++){
-    if (item.indexOf(suffix_check[i]) != -1 && ignored_names.indexOf(item) == -1) {
-      item = item.replace(suffix_check[i],'');
+  for (let i = 0; i < suffix_check.length; i++) {
+    if (itemName.indexOf(suffix_check[i]) != -1 && ignored_names.indexOf(itemName) == -1) {
+      itemName = itemName.replace(suffix_check[i], '');
     }
   }
-  return item;
+  return itemName;
 }
 
 /**

--- a/tools/dataProcessor.js
+++ b/tools/dataProcessor.js
@@ -231,7 +231,7 @@ function removeSuffixes(item) {
 
   // Removing suffixes
   for(let i = 0; i < suffix_check.length; i++){
-    if (item.indexOf(suffix_check[i]) != -1 && ignored_names.indexOf(item.site_name) == -1) {
+    if (item.indexOf(suffix_check[i]) != -1 && ignored_names.indexOf(item) == -1) {
       item = item.replace(suffix_check[i],'');
     }
   }


### PR DESCRIPTION
Bug fix for #83 

**Includes:**
- `ignored_names` list is now able to be checked, so names like `Hotels.com` will not be truncated
- The parameter `item` for `function removeSuffixes` renamed to `itemName` to make the code more clear
- Whitespace tidying (found a handy "format" option in VS code to make my code more cleaner)